### PR TITLE
fix verify-signature API call by adding network parameter

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -166,6 +166,7 @@ const getCookieByPrivateKey = async (ctx, key) => {
       .post("authentification/wallet/nonce", { address: signer.address })
       .then(async (r) => {
         return api.post('authentification/wallet/verify-signature', {
+          network: 1,
           sessionId: r.data.id,
           signature: await signer.signMessage(r.data.nonce)
         }).then(async (r) => {


### PR DESCRIPTION
seems like crew3 API has been updated - the parameter `network` is needed in the `verify-signature` API call